### PR TITLE
Update exposure_to_environmentalprocess.tsv

### DIFF
--- a/src/patterns/data/default/exposure_to_environmentalprocess.tsv
+++ b/src/patterns/data/default/exposure_to_environmentalprocess.tsv
@@ -55,3 +55,8 @@ ECTO:8000052	near-infrared radiation	NPO:1740
 ECTO:8000053	microwave radiation	ENVO:21001212
 ECTO:8000054	radiowave radiation	ENVO:21001213
 ECTO:8000055	ultrasound radiation	NPO:1744
+ECTO:7000042	exposure to particle radiation	ENVO:01001024
+ECTO:7000045	exposure to stellar radiation	ENVO:01001211	
+ECTO:7000047	exposure to ionizing radiation	ENVO:21001219
+ECTO:7000050	exposure to particle beam radiation	ENVO:01001025
+ECTO:7000053	exposure to radiation from a manufactured product	ENVO:21001217


### PR DESCRIPTION
Including additional radiation terms from incorrect placement in environmental_materials pattern. This includes the previous ECTO IDs as given in the pattern, but do we need to change them now? 
@diatomsRcool 